### PR TITLE
Fix free-run waveform chop and add Auto/Normal/Single trigger modes

### DIFF
--- a/gui/acquisition.py
+++ b/gui/acquisition.py
@@ -6,13 +6,13 @@ from vendor.hantek1008 import Hantek1008
 
 
 class AcquisitionThread(QThread):
-    new_frame = pyqtSignal(dict)
+    new_frame = pyqtSignal(dict, bool)  # (per-channel data, triggered)
     error = pyqtSignal(str)
     device_ready = pyqtSignal(dict)  # emits zero_offsets {vscale: [per-channel floats]}
 
     def __init__(self, ns_per_div=500_000, active_channels=None, vscales=None,
                  trigger_channel=0, trigger_slope="rising", trigger_level=2048,
-                 initial_pre_samples=2016, device=None, free_run=False, parent=None):
+                 initial_pre_samples=2016, device=None, capture_mode="auto", parent=None):
         super().__init__(parent)
         self._ns_per_div = ns_per_div
         self._active_channels = active_channels or [0]
@@ -21,12 +21,16 @@ class AcquisitionThread(QThread):
         self._trigger_slope = trigger_slope
         self._trigger_level = trigger_level
         self._initial_pre_samples = initial_pre_samples
-        self._free_run = free_run
+        self._capture_mode = capture_mode
         self._running = False
         self._stop_requested = False  # set by stop() to abort before entering the burst loop
         self._device = None
         # If an already-initialised device is supplied, we reuse it (no connect/init).
         self._existing_device = device
+
+    def _apply_capture_mode(self, device) -> None:
+        device.set_free_run(self._capture_mode == "auto")
+        device.set_single_mode(self._capture_mode == "single")
 
     def run(self):
         if self._existing_device is not None:
@@ -67,7 +71,7 @@ class AcquisitionThread(QThread):
                 self.error.emit(str(e))
                 return
 
-        device.set_free_run(self._free_run)
+        self._apply_capture_mode(device)
 
         self._running = True
         if self._stop_requested:
@@ -86,7 +90,7 @@ class AcquisitionThread(QThread):
                 # returns before a capture is ready)
                 if not data or any(len(v) == 0 for v in data.values()):
                     continue
-                self.new_frame.emit(data)
+                self.new_frame.emit(data, device.last_capture_triggered)
         finally:
             # ScopeWindow owns the device lifetime; we never close it here.
             self._device = None
@@ -99,10 +103,10 @@ class AcquisitionThread(QThread):
         if self._device is not None:
             self._device.queue_trigger_level(level)
 
-    def set_free_run(self, enabled: bool) -> None:
-        self._free_run = enabled
+    def set_capture_mode(self, mode: str) -> None:
+        self._capture_mode = mode
         if self._device is not None:
-            self._device.set_free_run(enabled)
+            self._apply_capture_mode(self._device)
 
     def stop(self):
         self._stop_requested = True

--- a/gui/controls.py
+++ b/gui/controls.py
@@ -74,12 +74,20 @@ def _trig_btn_style(color, is_selected, ch_is_active):
             "padding: 2px 3px; font-size: 11px;")
 
 
+def _mode_btn_style(is_selected):
+    if is_selected:
+        return ("background-color: #ff9900; color: #000000; border: none; "
+                "padding: 3px 6px; font-size: 11px; font-weight: bold;")
+    return ("background-color: #2a2a2a; color: #888888; border: 1px solid #444444; "
+            "padding: 3px 6px; font-size: 11px;")
+
+
 class ControlsPanel(QWidget):
     time_div_changed = pyqtSignal(int)       # ns_per_div
     channel_toggled = pyqtSignal(int, bool)  # ch_idx, is_on
     vscale_changed = pyqtSignal(int, float)  # ch_idx, vscale
     trigger_channel_changed = pyqtSignal(int)  # ch_idx
-    trigger_enabled_changed = pyqtSignal(bool)  # is_enabled
+    acq_mode_changed = pyqtSignal(str)       # "auto" | "normal"
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -89,8 +97,9 @@ class ControlsPanel(QWidget):
         self._active = {i: (i == 0) for i in range(8)}
         self._vscales = {i: 1.0 for i in range(8)}
         self._trigger_ch = 0
-        # Start the app in free-run by default so the display shows immediately, instead of waiting for a hardware trigger event.
-        self._trigger_enabled = False
+        # "auto" force-fires after a timeout (free-running scroll when no edge
+        # matches); "normal" holds the display until a matching edge arrives.
+        self._acq_mode = "auto"
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 10, 8, 8)
@@ -116,6 +125,30 @@ class ControlsPanel(QWidget):
         sep.setFixedHeight(1)
         sep.setStyleSheet("background-color: #333333; margin-top: 4px; margin-bottom: 2px;")
         layout.addWidget(sep)
+
+        lbl_trig = QLabel("Trigger Mode")
+        lbl_trig.setStyleSheet("color: #888888; font-size: 11px;")
+        layout.addWidget(lbl_trig)
+
+        mode_row = QWidget()
+        mode_row.setStyleSheet("background-color: transparent;")
+        mode_layout = QHBoxLayout(mode_row)
+        mode_layout.setContentsMargins(0, 0, 0, 0)
+        mode_layout.setSpacing(4)
+        self._auto_btn = QPushButton("Auto")
+        self._auto_btn.setToolTip("Free-run / scroll when no trigger edge matches")
+        self._normal_btn = QPushButton("Normal")
+        self._normal_btn.setToolTip("Hold the display until a trigger edge matches")
+        for btn, mode in ((self._auto_btn, "auto"), (self._normal_btn, "normal")):
+            btn.clicked.connect(lambda _, m=mode: self._on_acq_mode(m))
+            mode_layout.addWidget(btn)
+        layout.addWidget(mode_row)
+        self._update_mode_btn_styles()
+
+        sep2 = QLabel()
+        sep2.setFixedHeight(1)
+        sep2.setStyleSheet("background-color: #333333; margin-top: 4px; margin-bottom: 2px;")
+        layout.addWidget(sep2)
 
         lbl2 = QLabel("Channels")
         lbl2.setStyleSheet("color: #888888; font-size: 11px;")
@@ -202,23 +235,21 @@ class ControlsPanel(QWidget):
     def _on_trigger(self, ch_idx):
         if not self._active[ch_idx]:
             return
-        if ch_idx == self._trigger_ch and self._trigger_enabled:
-            # clicking the active trigger button → disable trigger (free-run)
-            self._trigger_enabled = False
-            self._update_trig_btn_styles()
-            self.trigger_enabled_changed.emit(False)
-            return
-        if not self._trigger_enabled:
-            # any T click while disabled → re-enable on that channel
-            prev_ch = self._trigger_ch
-            self._trigger_enabled = True
-            self._set_trigger_channel(ch_idx)
-            self.trigger_enabled_changed.emit(True)
-            if ch_idx != prev_ch:
-                self.trigger_channel_changed.emit(ch_idx)
+        if ch_idx == self._trigger_ch:
             return
         self._set_trigger_channel(ch_idx)
         self.trigger_channel_changed.emit(ch_idx)
+
+    def _on_acq_mode(self, mode):
+        if mode == self._acq_mode:
+            return
+        self._acq_mode = mode
+        self._update_mode_btn_styles()
+        self.acq_mode_changed.emit(mode)
+
+    def _update_mode_btn_styles(self):
+        self._auto_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "auto"))
+        self._normal_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "normal"))
 
     def _set_trigger_channel(self, ch_idx):
         self._trigger_ch = ch_idx
@@ -226,14 +257,17 @@ class ControlsPanel(QWidget):
 
     def _update_trig_btn_styles(self):
         for i, btn in enumerate(self._trig_btns):
-            is_selected = (i == self._trigger_ch) and self._trigger_enabled
+            is_selected = (i == self._trigger_ch)
             btn.setStyleSheet(_trig_btn_style(CHANNEL_COLORS[i], is_selected, self._active[i]))
 
     def get_trigger_channel(self):
         return self._trigger_ch
 
-    def is_trigger_enabled(self):
-        return self._trigger_enabled
+    def get_acq_mode(self):
+        return self._acq_mode
+
+    def is_free_run(self):
+        return self._acq_mode == "auto"
 
     def get_ns_per_div(self):
         return self._time_combo.currentData()

--- a/gui/controls.py
+++ b/gui/controls.py
@@ -87,7 +87,7 @@ class ControlsPanel(QWidget):
     channel_toggled = pyqtSignal(int, bool)  # ch_idx, is_on
     vscale_changed = pyqtSignal(int, float)  # ch_idx, vscale
     trigger_channel_changed = pyqtSignal(int)  # ch_idx
-    acq_mode_changed = pyqtSignal(str)       # "auto" | "normal"
+    acq_mode_changed = pyqtSignal(str)       # "auto" | "normal" | "single"
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -139,7 +139,10 @@ class ControlsPanel(QWidget):
         self._auto_btn.setToolTip("Free-run / scroll when no trigger edge matches")
         self._normal_btn = QPushButton("Normal")
         self._normal_btn.setToolTip("Hold the display until a trigger edge matches")
-        for btn, mode in ((self._auto_btn, "auto"), (self._normal_btn, "normal")):
+        self._single_btn = QPushButton("Single")
+        self._single_btn.setToolTip("Free-run until one trigger fires, then freeze on it")
+        for btn, mode in ((self._auto_btn, "auto"), (self._normal_btn, "normal"),
+                          (self._single_btn, "single")):
             btn.clicked.connect(lambda _, m=mode: self._on_acq_mode(m))
             mode_layout.addWidget(btn)
         layout.addWidget(mode_row)
@@ -247,9 +250,15 @@ class ControlsPanel(QWidget):
         self._update_mode_btn_styles()
         self.acq_mode_changed.emit(mode)
 
+    def clear_mode_selection(self):
+        """Deselect all mode buttons — used when a single-shot capture stops."""
+        self._acq_mode = "stopped"
+        self._update_mode_btn_styles()
+
     def _update_mode_btn_styles(self):
         self._auto_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "auto"))
         self._normal_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "normal"))
+        self._single_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "single"))
 
     def _set_trigger_channel(self, ch_idx):
         self._trigger_ch = ch_idx
@@ -265,9 +274,6 @@ class ControlsPanel(QWidget):
 
     def get_acq_mode(self):
         return self._acq_mode
-
-    def is_free_run(self):
-        return self._acq_mode == "auto"
 
     def get_ns_per_div(self):
         return self._time_combo.currentData()

--- a/gui/scope_window.py
+++ b/gui/scope_window.py
@@ -207,11 +207,11 @@ class ScopeWindow(QMainWindow):
         self._controls.channel_toggled.connect(self._on_channel_toggled)
         self._controls.vscale_changed.connect(self._on_vscale_changed)
         self._controls.trigger_channel_changed.connect(self._on_trigger_channel_changed)
-        self._controls.trigger_enabled_changed.connect(self._on_trigger_enabled_changed)
+        self._controls.acq_mode_changed.connect(self._on_acq_mode_changed)
 
-        # Align trigger marker visibility and internal state to the controls' initial setting
-        # so the UI doesn't start waiting for a trigger so user gets immediate display of readings.
-        self._on_trigger_enabled_changed(self._controls.is_trigger_enabled())
+        # The trigger markers are always active — the hardware trigger is always
+        # armed. In auto mode the device free-runs when no edge matches.
+        self._on_acq_mode_changed(self._controls.get_acq_mode())
 
     def _setup_plot(self):
         self._plot_widget.setBackground("#000000")
@@ -299,8 +299,9 @@ class ScopeWindow(QMainWindow):
 
     def _redraw(self):
         ns = self._controls.get_ns_per_div()
-        if not self._controls.is_trigger_enabled():
-            # Free-run: no trigger event to align to, just show the start of the buffer.
+        if self._controls.is_free_run():
+            # Auto mode: no triggered alignment, just show the start of the buffer
+            # (force-fired captures slide freely; matched captures stay put).
             start, end = 0, self._display_samples
         elif self._frame_size > self._display_samples:
             # The captured buffer is larger than the labeled time window — true
@@ -494,7 +495,7 @@ class ScopeWindow(QMainWindow):
             trigger_level=trig_adc,
             initial_pre_samples=initial_pre,
             device=self._device,
-            free_run=not self._controls.is_trigger_enabled(),
+            free_run=self._controls.is_free_run(),
         )
         self._acq.new_frame.connect(self.on_new_frame)
         self._acq.device_ready.connect(self._on_device_ready)
@@ -559,11 +560,11 @@ class ScopeWindow(QMainWindow):
         self._update_trigger_marker_label()
         self._restart_acquisition()
 
-    def _on_trigger_enabled_changed(self, enabled):
-        self._trigger_marker.setVisible(enabled)
-        self._h_trigger_marker.setVisible(enabled)
+    def _on_acq_mode_changed(self, mode):
+        self._trigger_marker.setVisible(True)
+        self._h_trigger_marker.setVisible(True)
         if self._acq is not None:
-            self._acq.set_free_run(not enabled)
+            self._acq.set_free_run(self._controls.is_free_run())
 
     def _on_vscale_changed(self, ch_idx, vscale):
         self._update_yrange()

--- a/gui/scope_window.py
+++ b/gui/scope_window.py
@@ -158,6 +158,7 @@ class ScopeWindow(QMainWindow):
         self._zero_offsets = {}          # {vscale: [per-channel float]} from device calibration
         self._frame_size = 0
         self._last_frame_np = {}         # {ch_id: np.ndarray} cached for drag redraws
+        self._last_frame_triggered = False  # was the displayed frame a real trigger?
 
         self._setup_ui()
         self._start_acquisition()
@@ -299,9 +300,9 @@ class ScopeWindow(QMainWindow):
 
     def _redraw(self):
         ns = self._controls.get_ns_per_div()
-        if self._controls.is_free_run():
-            # Auto mode: no triggered alignment, just show the start of the buffer
-            # (force-fired captures slide freely; matched captures stay put).
+        if not self._last_frame_triggered:
+            # Free-run / single-preview: no trigger event to align to, just show
+            # the start of the buffer so the trace slides freely.
             start, end = 0, self._display_samples
         elif self._frame_size > self._display_samples:
             # The captured buffer is larger than the labeled time window — true
@@ -495,7 +496,7 @@ class ScopeWindow(QMainWindow):
             trigger_level=trig_adc,
             initial_pre_samples=initial_pre,
             device=self._device,
-            free_run=self._controls.is_free_run(),
+            capture_mode=self._controls.get_acq_mode(),
         )
         self._acq.new_frame.connect(self.on_new_frame)
         self._acq.device_ready.connect(self._on_device_ready)
@@ -506,19 +507,27 @@ class ScopeWindow(QMainWindow):
         if self._acq is not None:
             self._acq.stop()
             self._restarting = True       # discard any frames that arrive from here on
-            self._status_label.setText("● Updating")
-            self._status_label.setStyleSheet(
-                "color: #ffaa00; font-size: 11px; background-color: #111111;"
-                "border-bottom: 1px solid #333333;"
-            )
+            self._set_status("● Updating", "#ffaa00")
             QApplication.processEvents()  # paint the status indicator immediately
             self._acq.wait()
             QApplication.processEvents()  # drain signals queued while wait() was blocking
         self._start_acquisition()
+        if self._controls.get_acq_mode() == "stopped":
+            self._set_status("● Stopped", "#ff5555")
 
-    def on_new_frame(self, data):
+    def _set_status(self, text, color):
+        self._status_label.setText(text)
+        self._status_label.setStyleSheet(
+            f"color: {color}; font-size: 11px; background-color: #111111;"
+            "border-bottom: 1px solid #333333;"
+        )
+
+    def on_new_frame(self, data, triggered):
         if self._restarting:
             return                        # discard stale frames from the dying thread
+        mode = self._controls.get_acq_mode()
+        if mode == "stopped":
+            return                        # single-shot captured; display is frozen
 
         expected = set(self._controls.get_active_channels())
         # data may include silent partner channels (hardware pair padding); filter them out
@@ -531,17 +540,19 @@ class ScopeWindow(QMainWindow):
         if not self._initialized:
             self._init_buffer(frame_size)
             self._initialized = True
-            self._status_label.setText("● Live")
-            self._status_label.setStyleSheet(
-                "color: #44cc44; font-size: 11px; background-color: #111111;"
-                "border-bottom: 1px solid #333333;"
-            )
+            self._set_status("● Live", "#44cc44")
 
+        self._last_frame_triggered = triggered
         self._last_frame_np = {
             ch_id: np.asarray(samples_list, dtype=np.float32)
             for ch_id, samples_list in data.items()
         }
         self._redraw()
+
+        if mode == "single" and triggered:
+            # Real trigger caught — freeze on this frame and deselect all modes.
+            self._controls.clear_mode_selection()
+            self._set_status("● Stopped", "#ff5555")
 
     def _on_time_div_changed(self, ns):
         log.info("===== USER changed time/div -> %d ns/div =====", ns)
@@ -564,7 +575,11 @@ class ScopeWindow(QMainWindow):
         self._trigger_marker.setVisible(True)
         self._h_trigger_marker.setVisible(True)
         if self._acq is not None:
-            self._acq.set_free_run(self._controls.is_free_run())
+            self._acq.set_capture_mode(mode)
+        if mode == "single":
+            self._set_status("● Armed", "#ffaa00")
+        elif self._initialized:
+            self._set_status("● Live", "#44cc44")
 
     def _on_vscale_changed(self, ch_idx, vscale):
         self._update_yrange()

--- a/vendor/hantek1008.py
+++ b/vendor/hantek1008.py
@@ -119,10 +119,16 @@ class Hantek1008Raw:
         self.__trigger_level_lock = Lock()
 
         self._free_run: bool = False  # free-run / untriggered display (device auto-fires)
+        self._single_mode: bool = False  # single-shot: free-run preview but report the real trigger
+        self.last_capture_triggered: bool = False  # True if the last burst was a natural trigger
 
     def set_free_run(self, enabled: bool) -> None:
         """Enable free-run / untriggered display, relying on the device's auto-fire timeout."""
         self._free_run = enabled
+
+    def set_single_mode(self, enabled: bool) -> None:
+        """Single-shot capture: free-run preview that still reports when a real trigger fires."""
+        self._single_mode = enabled
 
     def connect(self) -> None:
         """Find a plugged in hantek 1008c device and set up the connection to it"""
@@ -216,23 +222,37 @@ class Hantek1008Raw:
         log.debug("c6%02x got %d bytes (trimmed from %d)", parameter, sample_length, len(samples))
         return samples[0:sample_length]
 
-    def __send_a55a_command(self, attempts: int=20, force_after: Optional[int]=None) -> None:
+    def __send_a55a_command(self, attempts: int=20, force_after: Optional[int]=None,
+                            catch_natural: bool=False) -> bool:
+        """Poll until the capture buffer freezes.
+
+        Returns True if a *natural* trigger fired, False if the capture was
+        forced (free-run preview). In auto mode (force_after set, catch_natural
+        False) natural triggers before the force are ignored so the waveform
+        slides freely; in single mode (catch_natural True) a natural trigger
+        before the force is reported so the caller can freeze on it.
+        """
         responses = []
         for i in range(attempts):
+            forced = force_after is not None and i >= force_after
             # force_after: let the ring buffer fill for a few polls, then send
             # c2 (force capture) so free-run produces a frame even when no
-            # trigger edge matches. Natural triggers before the force are
-            # ignored so the waveform slides freely instead of locking onto a
-            # residual trigger level.
+            # trigger edge matches.
             if force_after is not None and i == force_after:
                 self.__send_cmd(0xc2)
             response = self.__send_cmd(0xa5, parameter=[0x5a], response_length=1)
             assert response[0] in [0, 1, 2, 3]
             responses.append(response[0])
-            if response[0] in [2, 3] and (force_after is None or i >= force_after):
-                log.debug("a55a fired after %d polls, responses=%s (ns/div=%d)",
-                         i + 1, responses, self.__ns_per_div)
-                return
+            if response[0] in [2, 3]:
+                if forced:
+                    return False
+                if force_after is None:
+                    return True   # normal mode: only ever a natural trigger
+                if catch_natural:
+                    log.debug("a55a natural trigger after %d polls (ns/div=%d)",
+                              i + 1, self.__ns_per_div)
+                    return True   # single mode: real trigger before the force
+                # auto mode: ignore natural triggers, keep polling until the force
             sleep(0.02)
             self.__send_ping()
         log.warning("a55a never fired, responses=%s (ns/div=%d)",
@@ -480,10 +500,14 @@ class Hantek1008Raw:
         # Must wait for a502 (buffer frozen) before reading; reading a live
         # buffer tears the c602/c603 halves. Free-run forces the capture with
         # c2 after a few polls so the frame slides freely with no trigger.
-        if self._free_run:
-            self.__send_a55a_command(attempts=200, force_after=7)
+        if self._single_mode:
+            self.last_capture_triggered = self.__send_a55a_command(
+                attempts=200, force_after=7, catch_natural=True)
+        elif self._free_run:
+            self.last_capture_triggered = self.__send_a55a_command(
+                attempts=200, force_after=7)
         else:
-            self.__send_a55a_command(attempts=20)
+            self.last_capture_triggered = self.__send_a55a_command(attempts=20)
 
         sample_response = self.__send_c6_a6_command(0x02)
         sample_response += self.__send_c6_a6_command(0x03)

--- a/vendor/hantek1008.py
+++ b/vendor/hantek1008.py
@@ -216,13 +216,20 @@ class Hantek1008Raw:
         log.debug("c6%02x got %d bytes (trimmed from %d)", parameter, sample_length, len(samples))
         return samples[0:sample_length]
 
-    def __send_a55a_command(self, attempts: int=20) -> None:
+    def __send_a55a_command(self, attempts: int=20, force_after: Optional[int]=None) -> None:
         responses = []
         for i in range(attempts):
+            # force_after: let the ring buffer fill for a few polls, then send
+            # c2 (force capture) so free-run produces a frame even when no
+            # trigger edge matches. Natural triggers before the force are
+            # ignored so the waveform slides freely instead of locking onto a
+            # residual trigger level.
+            if force_after is not None and i == force_after:
+                self.__send_cmd(0xc2)
             response = self.__send_cmd(0xa5, parameter=[0x5a], response_length=1)
             assert response[0] in [0, 1, 2, 3]
             responses.append(response[0])
-            if response[0] in [2, 3]:
+            if response[0] in [2, 3] and (force_after is None or i >= force_after):
                 log.debug("a55a fired after %d polls, responses=%s (ns/div=%d)",
                          i + 1, responses, self.__ns_per_div)
                 return
@@ -471,9 +478,12 @@ class Hantek1008Raw:
         self.__send_cmd(0xc0)
 
         # Must wait for a502 (buffer frozen) before reading; reading a live
-        # buffer tears the c602/c603 halves. Free-run relies on the device
-        # auto-firing after a timeout, hence the larger poll budget.
-        self.__send_a55a_command(attempts=200 if self._free_run else 20)
+        # buffer tears the c602/c603 halves. Free-run forces the capture with
+        # c2 after a few polls so the frame slides freely with no trigger.
+        if self._free_run:
+            self.__send_a55a_command(attempts=200, force_after=7)
+        else:
+            self.__send_a55a_command(attempts=20)
 
         sample_response = self.__send_c6_a6_command(0x02)
         sample_response += self.__send_c6_a6_command(0x03)

--- a/vendor/hantek1008.py
+++ b/vendor/hantek1008.py
@@ -118,10 +118,10 @@ class Hantek1008Raw:
         self.__pending_trigger_level: Optional[int] = None
         self.__trigger_level_lock = Lock()
 
-        self._free_run: bool = False  # skip a55a trigger wait when True
+        self._free_run: bool = False  # free-run / untriggered display (device auto-fires)
 
     def set_free_run(self, enabled: bool) -> None:
-        """Skip the hardware trigger wait in burst mode (free-run / untriggered display)."""
+        """Enable free-run / untriggered display, relying on the device's auto-fire timeout."""
         self._free_run = enabled
 
     def connect(self) -> None:
@@ -470,8 +470,10 @@ class Hantek1008Raw:
 
         self.__send_cmd(0xc0)
 
-        if not self._free_run:
-            self.__send_a55a_command()
+        # Must wait for a502 (buffer frozen) before reading; reading a live
+        # buffer tears the c602/c603 halves. Free-run relies on the device
+        # auto-firing after a timeout, hence the larger poll budget.
+        self.__send_a55a_command(attempts=200 if self._free_run else 20)
 
         sample_response = self.__send_c6_a6_command(0x02)
         sample_response += self.__send_c6_a6_command(0x03)


### PR DESCRIPTION
This PR adds explicit Auto / Normal / Single trigger modes.  Also fixes bug that was causing tearing/chop in free-run when the trigger wasn't matched.

I've also removed the ability to turn off the trigger in the UI, because there's no such thing as turning off the trigger in the hardware--it's always configured.  If you don't want a trigger, just use "Auto" and drag the trigger line away from the trace, then you'll get the expected free-run functionality with the trace scrolling about the screen.

What changed:
- Wait for the frozen buffer before reading in free-run
- Force capture in free-run so the waveform scrolls correctly
- Replace trigger on/off with Auto / Normal acquisition mode
- Add Single trigger acquisition mode

Closes #13
Closes #5