### PR TITLE
Add falling edge trigger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ https://github.com/user-attachments/assets/15a113a6-694e-49ce-842e-19c3c2059689
 - Up to 8 simultaneous channels, toggled on/off individually
 - Adjustable V/div per channel (10 mV – 5 V)
 - Adjustable time/div
-- Hardware trigger with selectable channel, level, and horizontal position
+- Hardware trigger with selectable channel, rising/falling edge, level, and horizontal position
+- Auto / Normal / Single trigger modes
+- Measurement cursor for on-screen Δt, frequency, and ΔV readouts
 - Draggable channel offset handles in a left margin strip
 - Channels stagger vertically on first enable so they don't stack on zero
 
@@ -51,12 +53,9 @@ python3 main.py
 
 ## Known limitations
 
-- Rising edge trigger only (falling edge not yet implemented)
 - No roll mode (continuous scrolling for slow signals)
 - No automatic measurements (Vpp, frequency, RMS, etc.)
-- No measurement cursors
 - No waveform export (CSV, image, etc.)
-- Trigger mode is normal only (no auto-trigger or single-shot)
 
 ## Project structure
 

--- a/gui/controls.py
+++ b/gui/controls.py
@@ -87,6 +87,7 @@ class ControlsPanel(QWidget):
     channel_toggled = pyqtSignal(int, bool)  # ch_idx, is_on
     vscale_changed = pyqtSignal(int, float)  # ch_idx, vscale
     trigger_channel_changed = pyqtSignal(int)  # ch_idx
+    trigger_slope_changed = pyqtSignal(str)  # "rising" | "falling"
     acq_mode_changed = pyqtSignal(str)       # "auto" | "normal" | "single"
     cursor_toggled = pyqtSignal(bool)        # measurement cursor on/off
 
@@ -98,6 +99,7 @@ class ControlsPanel(QWidget):
         self._active = {i: (i == 0) for i in range(8)}
         self._vscales = {i: 1.0 for i in range(8)}
         self._trigger_ch = 0
+        self._trigger_slope = "rising"
         # "auto" force-fires after a timeout (free-running scroll when no edge
         # matches); "normal" holds the display until a matching edge arrives.
         self._acq_mode = "auto"
@@ -149,6 +151,25 @@ class ControlsPanel(QWidget):
             mode_layout.addWidget(btn)
         layout.addWidget(mode_row)
         self._update_mode_btn_styles()
+
+        lbl_edge = QLabel("Trigger Edge")
+        lbl_edge.setStyleSheet("color: #888888; font-size: 11px;")
+        layout.addWidget(lbl_edge)
+
+        edge_row = QWidget()
+        edge_row.setStyleSheet("background-color: transparent;")
+        edge_layout = QHBoxLayout(edge_row)
+        edge_layout.setContentsMargins(0, 0, 0, 0)
+        edge_layout.setSpacing(4)
+        self._rising_btn = QPushButton("Rising ⤴")
+        self._rising_btn.setToolTip("Trigger on the rising / leading edge of the waveform")
+        self._falling_btn = QPushButton("Falling ⤵")
+        self._falling_btn.setToolTip("Trigger on the falling / trailing edge of the waveform")
+        for btn, slope in ((self._rising_btn, "rising"), (self._falling_btn, "falling")):
+            btn.clicked.connect(lambda _, s=slope: self._on_trigger_slope(s))
+            edge_layout.addWidget(btn)
+        layout.addWidget(edge_row)
+        self._update_slope_btn_styles()
 
         sep_cur = QLabel()
         sep_cur.setFixedHeight(1)
@@ -260,6 +281,13 @@ class ControlsPanel(QWidget):
         self._set_trigger_channel(ch_idx)
         self.trigger_channel_changed.emit(ch_idx)
 
+    def _on_trigger_slope(self, slope):
+        if slope == self._trigger_slope:
+            return
+        self._trigger_slope = slope
+        self._update_slope_btn_styles()
+        self.trigger_slope_changed.emit(slope)
+
     def _on_acq_mode(self, mode):
         if mode == self._acq_mode:
             return
@@ -288,6 +316,10 @@ class ControlsPanel(QWidget):
         self._normal_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "normal"))
         self._single_btn.setStyleSheet(_mode_btn_style(self._acq_mode == "single"))
 
+    def _update_slope_btn_styles(self):
+        self._rising_btn.setStyleSheet(_mode_btn_style(self._trigger_slope == "rising"))
+        self._falling_btn.setStyleSheet(_mode_btn_style(self._trigger_slope == "falling"))
+
     def _set_trigger_channel(self, ch_idx):
         self._trigger_ch = ch_idx
         self._update_trig_btn_styles()
@@ -299,6 +331,9 @@ class ControlsPanel(QWidget):
 
     def get_trigger_channel(self):
         return self._trigger_ch
+
+    def get_trigger_slope(self):
+        return self._trigger_slope
 
     def get_acq_mode(self):
         return self._acq_mode

--- a/gui/scope_window.py
+++ b/gui/scope_window.py
@@ -212,6 +212,7 @@ class ScopeWindow(QMainWindow):
         self._controls.channel_toggled.connect(self._on_channel_toggled)
         self._controls.vscale_changed.connect(self._on_vscale_changed)
         self._controls.trigger_channel_changed.connect(self._on_trigger_channel_changed)
+        self._controls.trigger_slope_changed.connect(self._on_trigger_slope_changed)
         self._controls.acq_mode_changed.connect(self._on_acq_mode_changed)
         self._controls.cursor_toggled.connect(self._on_cursor_toggled)
 
@@ -499,7 +500,7 @@ class ScopeWindow(QMainWindow):
             active_channels=hw_active,
             vscales=vscales_hw,
             trigger_channel=trig_ch,
-            trigger_slope="rising",
+            trigger_slope=self._controls.get_trigger_slope(),
             trigger_level=trig_adc,
             initial_pre_samples=initial_pre,
             device=self._device,
@@ -576,6 +577,9 @@ class ScopeWindow(QMainWindow):
 
     def _on_trigger_channel_changed(self, ch_idx):
         self._update_trigger_marker_label()
+        self._restart_acquisition()
+
+    def _on_trigger_slope_changed(self, slope):
         self._restart_acquisition()
 
     def _on_acq_mode_changed(self, mode):


### PR DESCRIPTION
## Summary

Implements the falling edge trigger feature requested in #1.

The hardware driver already supported selecting the trigger slope — the `0xc1` command encodes it as the last byte (`rising=0`, `falling=1`). I verified this against the vendor USB capture (`wip/trigger-falling-edge-leading-edge.pcapng`):

| Frame | Payload | Meaning |
|-------|---------|---------|
| 1557, 3233 | `c1 00 00` | initial — CH1, rising |
| 34277 | `c1 00 01` | switched to falling |
| 56605 | `c1 00 00` | switched back to rising |

The GUI was simply hard-coding `trigger_slope="rising"`, so this PR exposes the existing capability.

## Changes

- **`gui/controls.py`** — new "Trigger Edge" toggle (Rising ⤴ / Falling ⤵) with a `trigger_slope_changed` signal and `get_trigger_slope()` accessor.
- **`gui/scope_window.py`** — connect the signal to restart acquisition with the selected slope; replace the hard-coded `"rising"`.
- **`README.md`** — document rising/falling edge selection, plus the recently added Auto/Normal/Single trigger modes and measurement cursor; remove the now-stale limitations.

Closes #1